### PR TITLE
fix: fixing skyportal url by searching the right skyportal source id

### DIFF
--- a/src/grandma_gcn/gcn_stream/consumer.py
+++ b/src/grandma_gcn/gcn_stream/consumer.py
@@ -47,6 +47,11 @@ class Consumer(KafkaConsumer):
             "grb_alert_channel", self.gw_alert_channel
         )
 
+        # SkyPortal config for resolving source links
+        skyportal_config = gcn_stream.gcn_config.get("SKYPORTAL", {})
+        self.skyportal_base_url = skyportal_config.get("base_url", "")
+        self.skyportal_token = skyportal_config.get("token", "")
+
         # Subscribe to topics and receive alerts
         if gcn_stream.restart_queue:
             self.subscribe(
@@ -745,6 +750,12 @@ class Consumer(KafkaConsumer):
 
             if not should_send_slack:
                 return
+
+            if self.skyportal_base_url:
+                skyportal_link = grb_alert.get_skyportal_link(
+                    self.skyportal_base_url, self.skyportal_token
+                )
+                kwargs["skyportal_link"] = skyportal_link
 
             existing_thread = self._get_existing_thread(grb_alert.trigger_id)
             thread_ts = existing_thread.thread_ts if existing_thread else None

--- a/src/grandma_gcn/gcn_stream/grb_alert.py
+++ b/src/grandma_gcn/gcn_stream/grb_alert.py
@@ -2,6 +2,7 @@ import logging
 from enum import Enum
 from typing import Self
 
+import requests
 import voeventparse as vp
 
 from grandma_gcn.database.grb_db import GRB_alert as DBGRBAlert
@@ -254,16 +255,66 @@ class GRB_alert:
         return self._mission
 
     @property
-    def skyportal_link(self) -> str:
+    def source_search_id(self) -> str:
         """
-        Generate the SkyPortal link for this GRB.
+        Generate search ID used by SkyPortal (YYMMDD_HHMM format).
+
+        Seconds are not used because the VOEvent trigger time can differ by from SkyPortal's dateobs.
+
+        Returns
+        -------
+        str
+            Search ID (example: "260204_1448") or empty string
+        """
+        try:
+            event_time = vp.get_event_time_as_utc(self.voevent)
+            if event_time:
+                return event_time.strftime("%y%m%d_%H%M")
+            return ""
+        except Exception:
+            return ""
+
+    def get_skyportal_link(self, base_url: str, token: str) -> str:
+        """
+        Fetch the SkyPortal source link by querying the API.
+
+        SkyPortal source IDs are prefixed (e.g. "GCN-260204_144829", "GRB-260204_144829")
+        so we search by the date part and read the actual ID from the response.
+
+        Parameters
+        ----------
+        base_url : str
+            SkyPortal instance base URL
+        token : str
+            SkyPortal API token
 
         Returns
         -------
         str
             URL to the SkyPortal source page
         """
-        return f"https://skyportal-icare.ijclab.in2p3.fr/source/{self.trigger_id}"
+        search_id = self.source_search_id
+        if not search_id:
+            self.logger.warning("No trigger time available for SkyPortal search")
+            return f"{base_url}/source/{self.trigger_id}"
+
+        try:
+            response = requests.get(
+                f"{base_url}/api/sources",
+                headers={"Authorization": f"token {token}"},
+                params={"sourceID": search_id},
+                timeout=10,
+            )
+            response.raise_for_status()
+            data = response.json().get("data", {})
+            sources = data.get("sources", [])
+            if sources:
+                source_id = sources[0]["id"]
+                return f"{base_url}/source/{source_id}"
+        except Exception as e:
+            self.logger.warning(f"Error fetching SkyPortal source: {e}")
+
+        return f"{base_url}/source/{search_id}"
 
     @property
     def grb_name(self) -> str:

--- a/src/grandma_gcn/slackbot/grb_message.py
+++ b/src/grandma_gcn/slackbot/grb_message.py
@@ -111,13 +111,15 @@ def build_svom_alert_msg(grb_alert: GRB_alert, **kwargs) -> Message:
         return msg
 
     # For initial alert (packet 202) or first message
+    skyportal_link = kwargs.get("skyportal_link", "")
     message_text = (
         f"• *Trigger Time:* {grb_alert.trigger_time_formatted}\n"
         f"• *Rate_Signif:* {grb_alert.rate_signif} / *Image_Signif:* {grb_alert.image_signif} / *Trigger_Dur:* {grb_alert.trigger_dur}\n"
         f"• *Position:* RA {grb_alert.ra:.2f}, DEC {grb_alert.dec:.2f}\n"
-        f"• *Uncertainty:* {grb_alert.ra_dec_error_arcmin:.2f} arcmin\n"
-        f":grb: <{grb_alert.skyportal_link}|SkyPortal Link>"
+        f"• *Uncertainty:* {grb_alert.ra_dec_error_arcmin:.2f} arcmin"
     )
+    if skyportal_link:
+        message_text += f"\n:grb: <{skyportal_link}|SkyPortal Link>"
 
     msg.add_header(f"🔔 New SVOM GRB {grb_alert.grb_name} / {grb_alert.trigger_id}")
     msg.add_divider()
@@ -200,7 +202,9 @@ def build_swift_alert_msg(grb_alert: GRB_alert, **kwargs) -> Message:
         )
         message_text_parts.append(xrt_position)
 
-    message_text_parts.append(f":grb: <{first.skyportal_link}|SkyPortal Link>")
+    skyportal_link = kwargs.get("skyportal_link", "")
+    if skyportal_link:
+        message_text_parts.append(f":grb: <{skyportal_link}|SkyPortal Link>")
     message_text = "\n".join(message_text_parts)
 
     msg.add_header(

--- a/tests/gcn_stream_test.toml
+++ b/tests/gcn_stream_test.toml
@@ -44,3 +44,7 @@ galaxy_catalog = "mangrove"
 username = "test_user"
 password = "test_password"
 base_url = "https://owncloud.example.com"
+
+[SKYPORTAL]
+base_url = "https://skyportal-icare.ijclab.in2p3.fr"
+token = "skyportal_token"

--- a/tests/test_grb_alert.py
+++ b/tests/test_grb_alert.py
@@ -1,5 +1,9 @@
 """Tests for the GRB_alert class."""
 
+from unittest.mock import MagicMock
+
+import pytest
+
 from grandma_gcn.gcn_stream.grb_alert import GRB_alert, Mission
 
 
@@ -131,3 +135,110 @@ class TestGRBAlertFromDbModel:
         assert recreated.packet_type == swift_bat_alert.packet_type
 
         session.close()
+
+    def test_from_db_model_no_xml_payload(self):
+        """Test that ValueError is raised when xml_payload is None."""
+        mock_db = MagicMock()
+        mock_db.xml_payload = None
+        mock_db.triggerId = "test123"
+
+        with pytest.raises(ValueError, match="No XML payload"):
+            GRB_alert.from_db_model(mock_db)
+
+
+class TestGetSkyportalLink:
+    """Tests for the get_skyportal_link method."""
+
+    def test_get_skyportal_link_sources_found(self, swift_bat_alert: GRB_alert, mocker):
+        """Test that the correct URL is returned when a source is found."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "data": {"sources": [{"id": "GCN-260204_1448"}]}
+        }
+        mocker.patch(
+            "grandma_gcn.gcn_stream.grb_alert.requests.get",
+            return_value=mock_response,
+        )
+
+        link = swift_bat_alert.get_skyportal_link("https://skyportal.io", "token")
+
+        assert link == "https://skyportal.io/source/GCN-260204_1448"
+
+    def test_get_skyportal_link_no_sources(self, swift_bat_alert: GRB_alert, mocker):
+        """Test fallback URL when the API returns an empty sources list."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"data": {"sources": []}}
+        mocker.patch(
+            "grandma_gcn.gcn_stream.grb_alert.requests.get",
+            return_value=mock_response,
+        )
+
+        link = swift_bat_alert.get_skyportal_link("https://skyportal.io", "token")
+
+        assert "skyportal.io" in link
+
+    def test_get_skyportal_link_request_exception(
+        self, swift_bat_alert: GRB_alert, mocker
+    ):
+        """Test fallback URL when the request raises an exception."""
+        mocker.patch(
+            "grandma_gcn.gcn_stream.grb_alert.requests.get",
+            side_effect=Exception("Connection error"),
+        )
+
+        link = swift_bat_alert.get_skyportal_link("https://skyportal.io", "token")
+
+        assert "skyportal.io" in link
+
+    def test_get_skyportal_link_no_search_id(self, swift_bat_alert: GRB_alert, mocker):
+        """Test fallback to trigger_id when event time is unavailable (empty search_id)."""
+        mocker.patch(
+            "grandma_gcn.gcn_stream.grb_alert.vp.get_event_time_as_utc",
+            return_value=None,
+        )
+
+        link = swift_bat_alert.get_skyportal_link("https://skyportal.io", "token")
+
+        assert "skyportal.io" in link
+        assert swift_bat_alert.trigger_id in link
+
+
+class TestShouldProcessAlertEdgeCases:
+    """Tests for edge cases in should_process_alert."""
+
+    def test_svom_none_packet_type(self, svom_eclairs_alert: GRB_alert, mocker):
+        """Test that SVOM alert with no packet type is rejected."""
+        mocker.patch(
+            "grandma_gcn.gcn_stream.grb_alert.vp.get_toplevel_params",
+            return_value={},
+        )
+        assert svom_eclairs_alert.should_process_alert() is False
+
+    def test_svom_rejected_packet_type(self, svom_eclairs_alert: GRB_alert, mocker):
+        """Test that SVOM alert with an unsupported packet type is rejected."""
+        mocker.patch(
+            "grandma_gcn.gcn_stream.grb_alert.vp.get_toplevel_params",
+            return_value={"Packet_Type": {"value": "203"}},
+        )
+        assert svom_eclairs_alert.should_process_alert() is False
+
+    def test_swift_none_packet_type(self, swift_bat_alert: GRB_alert, mocker):
+        """Test that Swift alert with no packet type is rejected."""
+        mocker.patch(
+            "grandma_gcn.gcn_stream.grb_alert.vp.get_toplevel_params",
+            return_value={},
+        )
+        assert swift_bat_alert.should_process_alert() is False
+
+    def test_swift_rejected_packet_type(self, swift_bat_alert: GRB_alert, mocker):
+        """Test that Swift alert with an unsupported packet type is rejected."""
+        mocker.patch(
+            "grandma_gcn.gcn_stream.grb_alert.vp.get_toplevel_params",
+            return_value={"Packet_Type": {"value": "60"}},
+        )
+        assert swift_bat_alert.should_process_alert() is False
+
+    def test_unknown_mission_accepted(self, swift_bat_alert: GRB_alert):
+        """Test that alerts with unknown mission are accepted by default."""
+        swift_bat_alert._mission = Mission.UNKNOWN
+        assert swift_bat_alert.should_process_alert() is True

--- a/tests/test_grb_message.py
+++ b/tests/test_grb_message.py
@@ -1,7 +1,15 @@
 """Tests for GRB Slack message builders."""
 
+from unittest.mock import MagicMock
+
+import pytest
+
 from grandma_gcn.gcn_stream.grb_alert import GRB_alert
-from grandma_gcn.slackbot.grb_message import build_svom_alert_msg, build_swift_alert_msg
+from grandma_gcn.slackbot.grb_message import (
+    build_svom_alert_msg,
+    build_swift_alert_msg,
+    send_grb_alert_to_slack,
+)
 
 
 def test_build_swift_alert_msg_basic(swift_bat_alert: GRB_alert):
@@ -57,6 +65,19 @@ def test_build_swift_alert_msg_uvot_update(
     assert msg is not None
 
 
+def test_build_swift_alert_msg_with_skyportal_link(swift_bat_alert: GRB_alert):
+    """Test Swift alert message includes SkyPortal link when provided."""
+    skyportal_link = "https://skyportal.io/source/GCN-260204_1448"
+    msg = build_swift_alert_msg(
+        grb_alert=swift_bat_alert,
+        bat_alert=swift_bat_alert,
+        skyportal_link=skyportal_link,
+    )
+
+    assert msg is not None
+    assert "skyportal.io" in str(msg.blocks)
+
+
 def test_build_svom_alert_msg_basic(svom_eclairs_alert: GRB_alert):
     """Test basic SVOM alert message building."""
     msg = build_svom_alert_msg(grb_alert=svom_eclairs_alert)
@@ -67,14 +88,43 @@ def test_build_svom_alert_msg_basic(svom_eclairs_alert: GRB_alert):
     assert "SVOM" in blocks_str or "GRB" in blocks_str
 
 
+def test_build_svom_alert_msg_with_skyportal_link(svom_eclairs_alert: GRB_alert):
+    """Test SVOM alert message includes SkyPortal link when provided."""
+    skyportal_link = "https://skyportal.io/source/GCN-260208_1700"
+    msg = build_svom_alert_msg(
+        grb_alert=svom_eclairs_alert,
+        skyportal_link=skyportal_link,
+    )
+
+    assert msg is not None
+    assert "skyportal.io" in str(msg.blocks)
+
+
 def test_build_svom_alert_msg_thread_update(svom_eclairs_alert: GRB_alert):
-    """Test SVOM thread update message."""
+    """Test SVOM thread update message (packet 202 falls through to initial alert)."""
     msg = build_svom_alert_msg(
         grb_alert=svom_eclairs_alert,
         is_thread_update=True,
     )
 
     assert msg is not None
+
+
+def test_build_svom_alert_msg_thread_update_slew_packet(
+    svom_eclairs_alert: GRB_alert, mocker
+):
+    """Test SVOM thread update message with slew packet type (204/205)."""
+    mocker.patch(
+        "grandma_gcn.gcn_stream.grb_alert.vp.get_toplevel_params",
+        return_value={"Packet_Type": {"value": "204"}},
+    )
+    msg = build_svom_alert_msg(
+        grb_alert=svom_eclairs_alert,
+        is_thread_update=True,
+    )
+
+    assert msg is not None
+    assert "Slew" in str(msg.blocks)
 
 
 def test_build_svom_alert_msg_mxt_update(
@@ -88,3 +138,52 @@ def test_build_svom_alert_msg_mxt_update(
     )
 
     assert msg is not None
+
+
+def test_send_grb_alert_to_slack(svom_eclairs_alert: GRB_alert, logger):
+    """Test that send_grb_alert_to_slack calls the Slack API and returns the response."""
+    slack_client = MagicMock()
+    slack_client.chat_postMessage.return_value = {"ts": "12345"}
+
+    response = send_grb_alert_to_slack(
+        grb_alert=svom_eclairs_alert,
+        message_builder=build_svom_alert_msg,
+        slack_client=slack_client,
+        channel="#test-grb",
+        logger=logger,
+    )
+
+    assert slack_client.chat_postMessage.called
+    assert response == {"ts": "12345"}
+
+
+def test_send_grb_alert_to_slack_with_thread_ts(svom_eclairs_alert: GRB_alert, logger):
+    """Test that thread_ts is forwarded to the Slack API call."""
+    slack_client = MagicMock()
+
+    send_grb_alert_to_slack(
+        grb_alert=svom_eclairs_alert,
+        message_builder=build_svom_alert_msg,
+        slack_client=slack_client,
+        channel="#test-grb",
+        logger=logger,
+        thread_ts="1234567890.123456",
+    )
+
+    call_kwargs = slack_client.chat_postMessage.call_args[1]
+    assert call_kwargs["thread_ts"] == "1234567890.123456"
+
+
+def test_send_grb_alert_to_slack_failure(svom_eclairs_alert: GRB_alert, logger):
+    """Test that send_grb_alert_to_slack re-raises Slack API errors."""
+    slack_client = MagicMock()
+    slack_client.chat_postMessage.side_effect = Exception("Slack API error")
+
+    with pytest.raises(Exception, match="Slack API error"):
+        send_grb_alert_to_slack(
+            grb_alert=svom_eclairs_alert,
+            message_builder=build_svom_alert_msg,
+            slack_client=slack_client,
+            channel="#test-grb",
+            logger=logger,
+        )


### PR DESCRIPTION
The goal of this PR is to fix the Skyportal source link in the Slack message. 

The link was previously based on the trigger ID of the GCN event, but that is not how Skyportal source IDs are created.
Skyportal source IDs are based on the date of observation and are prefixed depending on the origin of the event. For example, the trigger SVOM `sb26021801` is saved as `GCN-260218_045328` in Skyportal. We need an intermediate step to get this ID and then we create the link. 
Skyportal links will not be shown if the Skyportal section is not configured.


Configuration section to add to enable this feature:

```
[SKYPORTAL]
base_url = "https://skyportal-icare.ijclab.in2p3.fr"
token = "skyportal_token"
```

Skyportal token should be generated in your Skyportal account. No specific ACL is required.